### PR TITLE
Added support to manage cron variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ cron_tasks: []
 cron_service_enabled: yes
 # current state: started, stopped
 cron_service_state: started
+
+
+# .. envvar:: cron_vars
+#
+# List of ``cron`` variables.
+# Refer to the `cronvar Ansible module documentation <https://docs.ansible.com/ansible/cronvar_module.html>`_ for details.
+#
+# Example::
+#
+#    cron_vars:
+#      - name: 'PATH'
+#        value: '/usr/bin:/bin:/usr/local/bin'
+#        user: 'root'
+#
+cron_vars: []
 ```
 
 ## Handlers
@@ -87,7 +102,7 @@ $ vagrant up
 ```
 
 ## Contributing
-In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests and examples for any new or changed functionality.
+In lieu of a formal style guide, take care to maintain the existing coding style. Add unit tests and examples for any new or changed functionality.
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,18 @@ cron_tasks: []
 cron_service_enabled: yes
 # current state: started, stopped
 cron_service_state: started
+
+
+# .. envvar:: cron_vars
+#
+# List of ``cron`` variables.
+# Refer to the `cronvar Ansible module documentation <https://docs.ansible.com/ansible/cronvar_module.html>`_ for details.
+#
+# Example::
+#
+#    cron_vars:
+#      - name: 'PATH'
+#        value: '/usr/bin:/bin:/usr/local/bin'
+#        user: 'root'
+#
+cron_vars: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: franklin
   company: We Are Interactive
   description: Installs and configures cron
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   license: MIT
   #
   # Below are all platforms currently available. Just uncomment

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -13,4 +13,16 @@
     state: "{{ item.state | default(omit) }}"
     user: "{{ item.user | default(omit) }}"
     weekday: "{{ item.weekday | default(omit) }}"
-  with_items: cron_tasks
+  with_items: '{{ cron_tasks }}'
+
+- name: Configuring cron variables
+  cronvar:
+    name: "{{ item.name | default(omit) }}"
+    value: "{{ item.value | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    cron_file: "{{ item.cron_file | default(omit) }}"
+    backup: "{{ item.backup | default(omit) }}"
+    insertafter: "{{ item.insertafter | default(omit) }}"
+    insertbefore: "{{ item.insertbefore | default(omit) }}"
+    user: "{{ item.user | default(omit) }}"
+  with_items: '{{ cron_vars }}'


### PR DESCRIPTION
The documentation format is that of the DebOps project which I find very nice. In case you don’t, I can change it to your plain format.
