### PR TITLE
Improve distributions handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ script:
   # Start The Built Container In The Background
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/${role}:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
-  # Optionally install dependencies
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install -c weareinteractive.apt weareinteractive.openssl franklinkim.htpasswd'
-
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/${role}/tests/main.yml --syntax-check'
 

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,4 +1,14 @@
 ---
 
-- name: Including variables
-  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
+- name: Set variables for CentOS
+  set_fact:
+    cron_package: "{{ cron_package | default('crontabs') }}"
+    cron_service_name: "{{ cron_service_name | default('crond') }}"
+  when: ansible_os_family == "RedHat"
+
+- name: Set variables for Debian/Ubuntu
+  set_fact:
+    cron_package: "{{ cron_package | default('cron') }}"
+    cron_service_name: "{{ cron_service_name | default('cron') }}"
+  when:
+    - ansible_os_family == "Debian"

--- a/vars/CentOS-Core.yml
+++ b/vars/CentOS-Core.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: crontabs
-# service name
-cron_service_name: crond

--- a/vars/Debian-jessie.yml
+++ b/vars/Debian-jessie.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: cron
-# service name
-cron_service_name: cron

--- a/vars/Debian-stretch.yml
+++ b/vars/Debian-stretch.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: cron
-# service name
-cron_service_name: cron

--- a/vars/Ubuntu-bionic.yml
+++ b/vars/Ubuntu-bionic.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: cron
-# service name
-cron_service_name: cron

--- a/vars/Ubuntu-trusty.yml
+++ b/vars/Ubuntu-trusty.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: cron
-# service name
-cron_service_name: cron

--- a/vars/Ubuntu-xenial.yml
+++ b/vars/Ubuntu-xenial.yml
@@ -1,6 +1,0 @@
----
-
-# package name
-cron_package: systemd-cron
-# service name
-cron_service_name: cron


### PR DESCRIPTION
This simplifies the distribution handling, and widen considerably the support of distributions of the RedHat and Debian family.
Furthermore, `cron_service_name` and `cron_service_name` can now be overridden.

The `cron` package is present on all Debian and Ubuntu distribution.
The `systemd-cron` package install lots of package like `exim4`, `mysql-common`, `guile`... weighting ~30Mb, that's why I think installing the `cron` package is enough.

If the user really wants `systemd-cron`, (s)he can set `cron_service_name`